### PR TITLE
Fixed build on Windows

### DIFF
--- a/nuts-and-bolts.lisp
+++ b/nuts-and-bolts.lisp
@@ -2,7 +2,7 @@
 
 (defun asdf-system-base-path (system-name)
   "Return the root directory of asdf system named NAME."
-  (directory-namestring (asdf:component-pathname (asdf:find-system system-name))))
+  (namestring (asdf:component-pathname (asdf:find-system system-name))))
 
 (defun data-path (name &key (verify t) (subdirectory "data"))
   "Return the path to the data file named NAME. If VERIFY is T, the existence of


### PR DESCRIPTION
On Windows (directory-namestring #P"c:/ws/academy/") is "/ws/academy/" and we need full pathname prefix.
